### PR TITLE
게시물 수정 비밀번호 해시값(수정 완료) + 답변 등록 시 화면 갱신 (완료)

### DIFF
--- a/app/src/main/java/kr/rabbito/shuttlelocationproject/MainActivity.kt
+++ b/app/src/main/java/kr/rabbito/shuttlelocationproject/MainActivity.kt
@@ -58,12 +58,12 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback {
         mapFragment.getMapAsync(this)
 
 //비밀번호 firebase에 올리기
-            Firebase.database.getReference("Manager").child("1").setValue("TEST1234".hashSHA256())
-            Firebase.database.getReference("Manager").child("2").setValue("S1L2P3".hashSHA256())
-            Firebase.database.getReference("Manager").child("3").setValue("1P12L23S3".hashSHA256())
-            Firebase.database.getReference("Manager").child("4").setValue("T1E2ST".hashSHA256())
-            Firebase.database.getReference("Manager").child("5").setValue("TEST".hashSHA256())
-            Firebase.database.getReference("Manager").child("6").setValue("mm0k211".hashSHA256())
+//            Firebase.database.getReference("Manager").child("1").setValue("TEST1234".hashSHA256())
+//            Firebase.database.getReference("Manager").child("2").setValue("S1L2P3".hashSHA256())
+//            Firebase.database.getReference("Manager").child("3").setValue("1P12L23S3".hashSHA256())
+//            Firebase.database.getReference("Manager").child("4").setValue("T1E2ST".hashSHA256())
+//            Firebase.database.getReference("Manager").child("5").setValue("TEST".hashSHA256())
+//            Firebase.database.getReference("Manager").child("6").setValue("mm0k211".hashSHA256())
 
 
         // 오류 무시

--- a/app/src/main/java/kr/rabbito/shuttlelocationproject/PostActivity.kt
+++ b/app/src/main/java/kr/rabbito/shuttlelocationproject/PostActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
@@ -17,7 +18,7 @@ import kr.rabbito.shuttlelocationproject.function.hashSHA256
 class PostActivity : AppCompatActivity() {
     private var mBinding: ActivityPostBinding? = null
     private val binding get() = mBinding!!
-
+    private val TAG="TAG"
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mBinding = ActivityPostBinding.inflate(layoutInflater)
@@ -37,7 +38,8 @@ class PostActivity : AppCompatActivity() {
                 postEtTitle.setText(tmpPost?.postTitle)
                 postEtContent.setText(tmpPost?.postContent)
                 //temp.postPassword = 암호화 알고리즘 적용된 비밀번호
-                postEtPassword.setText(tmpPost?.postPassword)
+                postEtPassword.setText(intent.getStringExtra("PostPassword"))
+                Log.d(TAG,"postEtPassword : $postEtPassword")
             }
         }
 
@@ -124,8 +126,8 @@ class PostActivity : AppCompatActivity() {
                 post.postId = tmpPostId!!
 
                 ref.child(post.postId).setValue(post)
-                val intent = Intent(this,CommunityActivity::class.java)
-                startActivity(intent)
+                intent.putExtra("EditPost",post)
+                Log.d(TAG,"EditPost password : $post.")
                 finish()
             }
             dlg.setView(dialogView)

--- a/app/src/main/java/kr/rabbito/shuttlelocationproject/PostDetailActivity.kt
+++ b/app/src/main/java/kr/rabbito/shuttlelocationproject/PostDetailActivity.kt
@@ -129,6 +129,9 @@ class PostDetailActivity : AppCompatActivity() {
             })
 
         }
+
+
+
         binding.postdetailBtnEdit.setOnClickListener {
             //deleteDialog 재 사용 -> editText.setText() 사용
             val dialog = DeleteDialog(this@PostDetailActivity)
@@ -144,10 +147,11 @@ class PostDetailActivity : AppCompatActivity() {
                         intent.putExtra("post", post)
                         intent.putExtra("PostMode", "Edit")
                         intent.putExtra("PostId", post.postId)
-                        intent.putExtra("PostPassword", post.postPassword)
-                        startActivity(intent)
+                        intent.putExtra("PostPassword", text)
                         //post 삭제
                         finish()
+                        startActivity(intent)
+
                     } else { // 게시물 비밀번호 다를 경우
                         Toast.makeText(this@PostDetailActivity, "잘못된 비밀번호입니다.", Toast.LENGTH_SHORT).show()
                     }
@@ -172,9 +176,20 @@ class PostDetailActivity : AppCompatActivity() {
                         comment.comment = text
                         comment.commentId = commentKey
                         commentRef.child(commentKey).setValue(comment)
+                        post.postCommentId = comment.commentId
+
+                        val tintent = Intent(this@PostDetailActivity, PostDetailActivity::class.java)
+
+                        val tmpbundle = Bundle()
+                        tmpbundle.putParcelable("selectedPost",post)
+                        tintent.putExtras(tmpbundle)
                         Toast.makeText(this@PostDetailActivity, "답변이 등록되었습니다.", Toast.LENGTH_SHORT)
                             .show()
+
+
                         finish()
+                        startActivity(tintent)
+
                     }
                 }
             })


### PR DESCRIPTION
게시물 수정할 때 비밀번호 해시값으로 뜨는 것 수정 -> 기존 비밀번호(암호화 안된)로 변경
Manager 답변 등록 시 

변경 전 : PostDetailActivity에서 답변 등록 -> CommunityActivity
변경 후 : PostDetailActivity에서 답변 등록 -> 기존 PostDetailActivity에 답변 추가된 것 갱신 
